### PR TITLE
Fix pip install with PEP 508 style for ancpbids

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,5 +1,5 @@
 alabaster==0.7.13
-git+https://github.com/karellopez/ancp-bids.git
+ancpbids @ git+https://github.com/karellopez/ancp-bids.git
 anyio==3.7.0
 appdirs==1.4.4
 appnope==0.1.3

--- a/meg_qc.egg-info/PKG-INFO
+++ b/meg_qc.egg-info/PKG-INFO
@@ -23,7 +23,7 @@ Classifier: Topic :: Scientific/Engineering
 Requires-Python: >=3.6
 Description-Content-Type: text/markdown
 License-File: LICENSE
-Requires-Dist: git+https://github.com/karellopez/ancp-bids.git
+Requires-Dist: ancpbids @ git+https://github.com/karellopez/ancp-bids.git
 Requires-Dist: prompt_toolkit==3.0.48
 Requires-Dist: mne~=1.6.0
 Requires-Dist: pandas>=2.0.3

--- a/meg_qc.egg-info/requires.txt
+++ b/meg_qc.egg-info/requires.txt
@@ -1,4 +1,4 @@
-git+https://github.com/karellopez/ancp-bids.git
+ancpbids @ git+https://github.com/karellopez/ancp-bids.git
 prompt_toolkit==3.0.48
 mne~=1.6.0
 pandas>=2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/karellopez/ancp-bids.git
+ancpbids @ git+https://github.com/karellopez/ancp-bids.git
 prompt_toolkit==3.0.48
 mne~=1.6.0
 pandas>=2.0.3


### PR DESCRIPTION
## Summary
- correct the ancpbids dependency syntax so it uses PEP 508 direct URL
- update docs and egg metadata accordingly

## Testing
- `pytest -q`
- `pip install -e .` *(fails: Cannot install on Python version 3.12.10; only versions >=3.8,<3.12 are supported)*

------
https://chatgpt.com/codex/tasks/task_e_68557426214083269b821fd33dfd36aa