### PR TITLE
Fix contamination level metric key

### DIFF
--- a/meg_qc/calculation/meg_qc_pipeline.py
+++ b/meg_qc/calculation/meg_qc_pipeline.py
@@ -135,8 +135,8 @@ def create_summary_report(json_file: Union[str, os.PathLike], html_output: str =
             })
         return pd.DataFrame(results), percentages
 
-    ecg_df, ecg_percents = count_high_correlations_from_details("ECG", "all_channels_raned_by_ECG_contamination_level")
-    eog_df, eog_percents = count_high_correlations_from_details("EOG", "all_channels_raned_by_EOG_contamination_level")
+    ecg_df, ecg_percents = count_high_correlations_from_details("ECG", "all_channels_ranked_by_ECG_contamination_level")
+    eog_df, eog_percents = count_high_correlations_from_details("EOG", "all_channels_ranked_by_EOG_contamination_level")
 
     correlation_percent_avg = (sum(ecg_percents + eog_percents) / len(ecg_percents + eog_percents)) / 2
     raw_gqi = sum(quality_values) / len(quality_values)

--- a/meg_qc/calculation/metrics/ECG_EOG_meg_qc.py
+++ b/meg_qc/calculation/metrics/ECG_EOG_meg_qc.py
@@ -1448,7 +1448,7 @@ def make_simple_metric_ECG_EOG(channels_ranked: dict, m_or_g_chosen: List, ecg_o
         
     """
 
-    metric_global_name = 'all_channels_raned_by_'+ecg_or_eog+'_contamination_level'
+    metric_global_name = 'all_channels_ranked_by_'+ecg_or_eog+'_contamination_level'
     metric_global_content = {'mag': None, 'grad': None}
 
     if use_method == 'mean_threshold':


### PR DESCRIPTION
## Summary
- rename contamination level key to `all_channels_ranked_by_*` in ECG/EOG metrics
- update global summary report to use the corrected key

## Testing
- `python -m compileall meg_qc`

------
https://chatgpt.com/codex/tasks/task_e_686cdc7bb9a08326bf6579d3f46e2ac4