### PR TITLE
Fix global report crash on missing ECG/EOG correlation details

### DIFF
--- a/tests/test_global_report.py
+++ b/tests/test_global_report.py
@@ -1,0 +1,65 @@
+import json
+import os
+from meg_qc.calculation.meg_qc_pipeline import create_summary_report
+
+def test_create_summary_report_handles_missing_corr(tmp_path):
+    data = {
+        "STD": {
+            "STD_all_time_series": {
+                "mag": {
+                    "number_of_noisy_ch": 0,
+                    "percent_of_noisy_ch": 0,
+                    "number_of_flat_ch": 0,
+                    "percent_of_flat_ch": 0,
+                    "std_lvl": 0
+                },
+                "grad": {
+                    "number_of_noisy_ch": 0,
+                    "percent_of_noisy_ch": 0,
+                    "number_of_flat_ch": 0,
+                    "percent_of_flat_ch": 0
+                }
+            },
+            "STD_epoch": {
+                "mag": {"noisy_channel_multiplier": 0},
+                "grad": {"noisy_channel_multiplier": 0}
+            }
+        },
+        "PTP_MANUAL": {
+            "ptp_manual_all": {
+                "mag": {
+                    "number_of_noisy_ch": 0,
+                    "percent_of_noisy_ch": 0,
+                    "number_of_flat_ch": 0,
+                    "percent_of_flat_ch": 0,
+                    "ptp_lvl": 0
+                },
+                "grad": {
+                    "number_of_noisy_ch": 0,
+                    "percent_of_noisy_ch": 0,
+                    "number_of_flat_ch": 0,
+                    "percent_of_flat_ch": 0
+                }
+            },
+            "ptp_manual_epoch": {
+                "mag": {"noisy_channel_multiplier": 0},
+                "grad": {"noisy_channel_multiplier": 0}
+            }
+        },
+        "PSD": {"present": True},
+        "MUSCLE": {"zscore_thresholds": {"number_muscle_events": 0}},
+        "ECG": {"description": "ECG channel noisy"},
+        "EOG": {"description": "EOG channel noisy"}
+    }
+    json_file = tmp_path / "metrics.json"
+    html_file = tmp_path / "report.html"
+    summary_json = tmp_path / "summary.json"
+    json_file.write_text(json.dumps(data))
+
+    create_summary_report(str(json_file), str(html_file), str(summary_json))
+
+    assert html_file.exists()
+    with open(summary_json) as f:
+        summary = json.load(f)
+    assert summary["ECG_correlation_summary"][0]["Total Channels"] == 0
+    assert summary["EOG_correlation_summary"][0]["Total Channels"] == 0


### PR DESCRIPTION
## Summary
- make `count_high_correlations_from_details` robust when correlation data is missing in the JSON metrics
- add regression test for summary report generation when ECG/EOG correlation data is absent

## Testing
- `pip install -e .` *(fails: Python version too new)*
- `pytest -q` *(fails: missing dependency `ancpbids`)*

------
https://chatgpt.com/codex/tasks/task_e_686d0d59ed44832681207160295d1036