### PR TITLE
Fix STD epoch metric index mismatch

### DIFF
--- a/meg_qc/calculation/metrics/STD_meg_qc.py
+++ b/meg_qc/calculation/metrics/STD_meg_qc.py
@@ -211,8 +211,9 @@ def get_noisy_flat_std_ptp_epochs(df_std: pd.DataFrame, ch_type: str, std_or_ptp
         # ratio is NaN for channels with zero mean; these are marked not noisy/flat
         # by replacing NaN with False in the boolean comparison results
         df_epoch_vs_mean.iloc[:, ep] = ratio
-        df_noisy_epoch.iloc[:, ep] = (ratio > noisy_channel_multiplier).fillna(False)
-        df_flat_epoch.iloc[:, ep] = (ratio < flat_multiplier).fillna(False)
+        # Assign only to the original channel rows to avoid length mismatch
+        df_noisy_epoch.iloc[:-3, ep] = (ratio > noisy_channel_multiplier).fillna(False)
+        df_flat_epoch.iloc[:-3, ep] = (ratio < flat_multiplier).fillna(False)
 
         # Calculate the number of noisy/flat channels in this epoch:
         df_noisy_epoch.loc['number noisy channels', ep] = df_noisy_epoch.iloc[:-3,ep].sum()


### PR DESCRIPTION
## Summary
- correct row assignment in STD epoch calculations to avoid length mismatch errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d22dbe2448326a3050b990e6492f7