### PR TITLE
Add PSD to GQI and muscle event count

### DIFF
--- a/tests/test_global_report.py
+++ b/tests/test_global_report.py
@@ -46,7 +46,12 @@ def test_create_summary_report_handles_missing_corr(tmp_path):
                 "grad": {"noisy_channel_multiplier": 0}
             }
         },
-        "PSD": {"present": True},
+        "PSD": {
+            "PSD_global": {
+                "mag": {"details": {}},
+                "grad": {"details": {}},
+            }
+        },
         "MUSCLE": {
             "zscore_thresholds": {"number_muscle_events": 0},
             "total_number_of_events": 100,
@@ -66,3 +71,4 @@ def test_create_summary_report_handles_missing_corr(tmp_path):
         summary = json.load(f)
     assert summary["ECG_correlation_summary"][0]["Total Channels"] == 0
     assert summary["EOG_correlation_summary"][0]["Total Channels"] == 0
+    assert summary["Muscle_events"]["total_number_of_events"] == 100


### PR DESCRIPTION
## Summary
- include PSD noise power in summary report generation
- adjust GQI weights and compute PSD sub-index
- show total muscle events in HTML and JSON outputs
- adapt tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e605c307883269f8dd96c2211be64