### PR TITLE
Add PSD info to global summary

### DIFF
--- a/tests/test_global_report.py
+++ b/tests/test_global_report.py
@@ -72,3 +72,4 @@ def test_create_summary_report_handles_missing_corr(tmp_path):
     assert summary["ECG_correlation_summary"][0]["Total Channels"] == 0
     assert summary["EOG_correlation_summary"][0]["Total Channels"] == 0
     assert summary["Muscle_events"]["total_number_of_events"] == 100
+    assert summary["PSD_noise_summary"][0]["MAGNETOMETERS"] == "0.00%"


### PR DESCRIPTION
## Summary
- compute PSD noise percentage for magnetometers and gradiometers
- show PSD table in HTML summary
- output PSD noise summary in JSON
- test for PSD noise summary field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e655310448326a6b3bd36be091845