### PR TITLE
Extend group metrics TSV

### DIFF
--- a/meg_qc/calculation/meg_qc_pipeline.py
+++ b/meg_qc/calculation/meg_qc_pipeline.py
@@ -1458,9 +1458,13 @@ def make_derivative_meg_qc(
                 with open(path, "r", encoding="utf-8") as f:
                     js = json.load(f)
                 subject = os.path.basename(os.path.dirname(path))
-                metrics = js.get("GQI_metrics", {})
-                row = {"subject": subject, "GQI": js.get("GQI")}
-                row.update(metrics)
+
+                row = {"subject": subject}
+                for key, val in js.items():
+                    if isinstance(val, (dict, list)):
+                        row[key] = json.dumps(val)
+                    else:
+                        row[key] = val
                 rows.append(row)
 
             if rows:


### PR DESCRIPTION
## Summary
- include all metrics when building group-level table by reading entire JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f8f8f9df88326b8ceea14e93dd80a