### PR TITLE
Add GQI group metrics violin plots

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ joblib==1.4.2
 pyqt6-tools==6.4.2.3.3
 numba==0.58.1
 psutil==5.9.8
+matplotlib==3.8.4

--- a/tests/test_group_figure.py
+++ b/tests/test_group_figure.py
@@ -1,0 +1,23 @@
+import os
+import pandas as pd
+from meg_qc.calculation.metrics.summary_report_GQI import create_group_metrics_figure
+
+
+def test_create_group_metrics_figure(tmp_path):
+    df = pd.DataFrame({
+        'GQI': [80, 90],
+        'GQI_penalty_ch': [10, 5],
+        'GQI_penalty_corr': [0, 5],
+        'GQI_penalty_mus': [5, 0],
+        'GQI_penalty_psd': [2, 3],
+        'GQI_bad_pct': [1.0, 2.0],
+        'GQI_ecg_pct': [0.1, 0.2],
+        'GQI_eog_pct': [0.1, 0.0],
+        'GQI_muscle_pct': [0.01, 0.02],
+        'GQI_psd_noise_pct': [3.0, 4.0],
+    })
+    tsv = tmp_path / 'data.tsv'
+    df.to_csv(tsv, sep='\t', index=False)
+    png = tmp_path / 'out.png'
+    create_group_metrics_figure(tsv, png)
+    assert png.exists()


### PR DESCRIPTION
## Summary
- generate and save violin plot of Global Quality Index group metrics
- save the plot alongside TSV metrics for each attempt
- add matplotlib to requirements
- test plot creation

## Testing
- `pip install ancpbids==0.3.0 prompt_toolkit==3.0.48 "mne~=1.6.0" pandas>=2.0.3 plotly==5.24.1 joblib==1.4.2 psutil==5.9.8 matplotlib==3.8.4`
- `pip install numba==0.61.2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68763bbf87248326909a4af3796d27ae