### PR TITLE
Allow GQI without muscle metric

### DIFF
--- a/tests/test_flatten_summary.py
+++ b/tests/test_flatten_summary.py
@@ -35,6 +35,8 @@ def test_flatten_summary_metrics():
         "GQI_penalties": {"ch": 0.0, "corr": 0.0, "mus": 0.0, "psd": 20.0},
         "GQI_metrics": {
             "bad_pct": 9.1875,
+            "std_pct": 4.0,
+            "ptp_pct": 5.0,
             "ecg_pct": 0.0,
             "eog_pct": 0.0,
             "muscle_pct": 0.0001845015046097701,
@@ -51,4 +53,6 @@ def test_flatten_summary_metrics():
     assert row["PSD_noise_mag_percentage"] == 49.48
     assert row["Muscle_events_num"] == 1
     assert row["GQI_penalty_psd"] == 20.0
+    assert row["GQI_std_pct"] == 4.0
+    assert row["GQI_ptp_pct"] == 5.0
 

--- a/tests/test_group_figure.py
+++ b/tests/test_group_figure.py
@@ -11,6 +11,8 @@ def test_create_group_metrics_figure(tmp_path):
         'GQI_penalty_mus': [5, 0],
         'GQI_penalty_psd': [2, 3],
         'GQI_bad_pct': [1.0, 2.0],
+        'GQI_std_pct': [0.5, 0.6],
+        'GQI_ptp_pct': [0.5, 1.4],
         'GQI_ecg_pct': [0.1, 0.2],
         'GQI_eog_pct': [0.1, 0.0],
         'GQI_muscle_pct': [0.01, 0.02],


### PR DESCRIPTION
## Summary
- compute GQI even when the muscle metric is missing
- expose channel percentages separately as `GQI_std_pct` and `GQI_ptp_pct`
- plot the new metrics in group figures
- update tests for new output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1af3bc848326a799bb018e2299dc