### PR TITLE
Fix CTF handling for missing stim channels

### DIFF
--- a/meg_qc/calculation/initial_meg_qc.py
+++ b/meg_qc/calculation/initial_meg_qc.py
@@ -316,14 +316,17 @@ def stim_data_to_df(raw: mne.io.Raw):
     """
 
     stim_channels = mne.pick_types(raw.info, stim=True)
-    stim_channel_names = [raw.info['ch_names'][ch] for ch in stim_channels]
 
-    # Extract data for stimulus channels
-    stim_data, times = raw[stim_channels, :]
-
-    # Create a DataFrame with the stimulus data
-    stim_df = pd.DataFrame(stim_data.T, columns=stim_channel_names)
-    stim_df['time'] = times
+    if len(stim_channels) == 0:
+        print('___MEGqc___: ', 'No stimulus channels found.')
+        stim_df = pd.DataFrame()
+    else:
+        stim_channel_names = [raw.info['ch_names'][ch] for ch in stim_channels]
+        # Extract data for stimulus channels
+        stim_data, times = raw[stim_channels, :]
+        # Create a DataFrame with the stimulus data
+        stim_df = pd.DataFrame(stim_data.T, columns=stim_channel_names)
+        stim_df['time'] = times
 
     # save df as QC_derivative object
     stim_deriv = [QC_derivative(stim_df, 'stimulus', 'df')]


### PR DESCRIPTION
## Summary
- avoid crashing when CTF files have no stimulus channels
- compute PSD/GQI metrics without assuming magnetometers are present
- handle missing sensor types when summarising STD and PTP metrics

## Testing
- `pip install -q mne==1.6.1 pandas==2.2.0 plotly==5.24.1 joblib==1.4.2 numba==0.59.1 psutil==5.9.8 matplotlib==3.8.4 ancpbids==0.3.0 prompt_toolkit==3.0.48`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5d5956d88326ba976ca6bb1b0737