### PR TITLE
Update GQI plots and add cumulative analysis

### DIFF
--- a/meg_qc/calculation/metrics/summary_report_GQI.py
+++ b/meg_qc/calculation/metrics/summary_report_GQI.py
@@ -511,7 +511,6 @@ def create_group_metrics_figure(tsv_path: Union[str, os.PathLike], output_png: U
         "GQI_penalty_corr",
         "GQI_penalty_mus",
         "GQI_penalty_psd",
-        "GQI_bad_pct",
         "GQI_std_pct",
         "GQI_ptp_pct",
         "GQI_ecg_pct",
@@ -519,6 +518,20 @@ def create_group_metrics_figure(tsv_path: Union[str, os.PathLike], output_png: U
         "GQI_muscle_pct",
         "GQI_psd_noise_pct",
     ]
+
+    label_map = {
+        "GQI": "GQI",
+        "GQI_penalty_ch": "Variability penalty",
+        "GQI_penalty_corr": "Correlational penalty",
+        "GQI_penalty_mus": "Muscle penalty",
+        "GQI_penalty_psd": "PSD penalty",
+        "GQI_std_pct": "STD noise",
+        "GQI_ptp_pct": "PtP noise",
+        "GQI_ecg_pct": "ECG noise",
+        "GQI_eog_pct": "EOG noise",
+        "GQI_muscle_pct": "Muscle noise",
+        "GQI_psd_noise_pct": "PSD noise",
+    }
     # Only plot metrics present in the table and containing data
     available_cols = [
         c for c in cols if c in df.columns and not df[c].dropna().empty
@@ -563,7 +576,15 @@ def create_group_metrics_figure(tsv_path: Union[str, os.PathLike], output_png: U
         )
 
     # Label axes and finalise the figure
-    plt.xticks(range(1, len(available_cols) + 1), available_cols, rotation=35, ha="right", fontsize=20, fontweight="bold")
+    tick_labels = [label_map.get(c, c) for c in available_cols]
+    plt.xticks(
+        range(1, len(available_cols) + 1),
+        tick_labels,
+        rotation=35,
+        ha="right",
+        fontsize=20,
+        fontweight="bold",
+    )
     plt.yticks(fontsize=18)
     plt.ylabel("Value", fontsize=22, fontweight="bold")
     plt.title("Violin Plot of GQI Metrics with Individual Data Points", fontsize=26, pad=25)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyqt6-tools==6.4.2.3.3
 numba==0.58.1
 psutil==5.9.8
 matplotlib==3.8.4
+statsmodels

--- a/tests/test_group_figure.py
+++ b/tests/test_group_figure.py
@@ -10,7 +10,6 @@ def test_create_group_metrics_figure(tmp_path):
         'GQI_penalty_corr': [0, 5],
         'GQI_penalty_mus': [5, 0],
         'GQI_penalty_psd': [2, 3],
-        'GQI_bad_pct': [1.0, 2.0],
         'GQI_std_pct': [0.5, 0.6],
         'GQI_ptp_pct': [0.5, 1.4],
         'GQI_ecg_pct': [0.1, 0.2],
@@ -27,7 +26,6 @@ def test_create_group_metrics_figure(tmp_path):
 
 def test_group_figure_handles_missing_columns(tmp_path):
     df = pd.DataFrame({
-        'GQI_bad_pct': [1.0, 2.0],
         'GQI_psd_noise_pct': [3.0, 4.0],
     })
     tsv = tmp_path / 'data2.tsv'


### PR DESCRIPTION
## Summary
- rename labels used in the GQI group plot and drop `GQI_bad_pct`
- add `statsmodels` as a dependency
- adapt between sample analysis labels and add a cumulative violin plot
- update tests for changed labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68833f0e75408326bf37bb7eb15ca525