### PR TITLE
Per-sample mutual information computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ pipeline, run::
 
 All violin plots and regression results will be written to the ``results``
 directory. Significant regression coefficients are marked with asterisks.
+For each sample a mutual information analysis of the noise metrics is saved in
+the ``mutual_information`` folder alongside a combined analysis that
+treats all samples as one dataset.

--- a/meg_qc/calculation/between_sample_analysis.py
+++ b/meg_qc/calculation/between_sample_analysis.py
@@ -347,6 +347,16 @@ def main():
         df_all, metrics, os.path.join(regression_dir, "linear_regression_results.tsv")
     )
 
+    # Mutual information per sample
+    for name, tbl in zip(args.names, tables):
+        _mutual_information(
+            tbl,
+            metrics,
+            os.path.join(mi_dir, f"{name}_mutual_information.png"),
+            os.path.join(mi_dir, f"{name}_mutual_information.tsv"),
+        )
+
+    # Mutual information across all samples
     _mutual_information(
         df_all,
         metrics,


### PR DESCRIPTION
## Summary
- compute mutual information for each sample in between_sample_analysis
- keep combined MI analysis across all samples
- clarify MI output location in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c8c6a8be48326916a5a019c41e179