### PR TITLE
Extend mutual information analysis with significance testing and normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ pipeline, run::
 
 All violin plots and regression results will be written to the ``results``
 directory. Significant regression coefficients are marked with asterisks.
-For each sample a mutual information analysis of the noise metrics is saved in
-the ``mutual_information`` folder alongside a combined analysis that
-treats all samples as one dataset.
+
+To add a mutual information (MI) analysis, include the ``--mi`` flag. A
+permutation-based significance test can be enabled with ``--mi-permutation``
+and the number of permutations controlled via ``--mi-permutations``. For
+example::
+
+    python -m meg_qc.calculation.between_sample_analysis \
+        --tsv sample1/group_metrics.tsv sample2/group_metrics.tsv \
+        --names sample1 sample2 \
+        --output-dir results \
+        --mi --mi-permutation --mi-permutations 1000
+
+MI results (raw, net, z-scores, p-values, normalized variants and entropies)
+are stored in the ``mutual_information`` folder for each sample and for the
+combined dataset.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ psutil==5.9.8
 matplotlib==3.8.4
 statsmodels
 scikit-learn
+seaborn


### PR DESCRIPTION
## Summary
- add `analyze_mutual_information` high-level function with permutation-based significance test, entropy estimation and normalized MI
- expose new CLI flags to trigger MI analysis, control permutations and output redundancy summaries
- document MI usage and add seaborn dependency

## Testing
- `PYTHONPATH=. pytest tests/test_mutual_info.py::test_mutual_information -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'ancpbids')*


------
https://chatgpt.com/codex/tasks/task_e_689075b1192c83269bfc0fc32f5a5d01