### PR TITLE
Fix MI permutation parallelization and simplify CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,15 @@ pipeline, run::
 All violin plots and regression results will be written to the ``results``
 directory. Significant regression coefficients are marked with asterisks.
 
-To add a mutual information (MI) analysis, include the ``--mi`` flag. A
-permutation-based significance test can be enabled with ``--mi-permutation``
-and the number of permutations controlled via ``--mi-permutations``. For
-example::
+To add a mutual information (MI) analysis, include the ``--mi`` flag. The
+number of permutations for the significance test is controlled via
+``--mi-permutations`` (use ``0`` to disable permutation testing). For example::
 
     python -m meg_qc.calculation.between_sample_analysis \
         --tsv sample1/group_metrics.tsv sample2/group_metrics.tsv \
         --names sample1 sample2 \
         --output-dir results \
-        --mi --mi-permutation --mi-permutations 1000
+        --mi --mi-permutations 1000
 
 MI results (raw, net, z-scores, p-values, normalized variants and entropies)
 are stored in the ``mutual_information`` folder for each sample and for the

--- a/tests/test_mutual_info.py
+++ b/tests/test_mutual_info.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from meg_qc.calculation.between_sample_analysis import _mutual_information
+from meg_qc.calculation.between_sample_analysis import _mutual_information, analyze_mutual_information
 
 
 def test_mutual_information(tmp_path):
@@ -16,3 +16,23 @@ def test_mutual_information(tmp_path):
     _mutual_information(df, list(df.columns), png, tsv)
     assert tsv.exists()
     assert png.exists()
+
+
+def test_mutual_information_with_permutation():
+    df = pd.DataFrame({
+        'GQI_std_pct': [0.1, 0.2, 0.15],
+        'GQI_ptp_pct': [0.3, 0.4, 0.35],
+        'GQI_ecg_pct': [0.05, 0.1, 0.08],
+        'GQI_eog_pct': [0.02, 0.03, 0.025],
+        'GQI_muscle_pct': [0.01, 0.02, 0.015],
+        'GQI_psd_noise_pct': [0.5, 0.6, 0.55],
+    })
+    res = analyze_mutual_information(
+        df,
+        list(df.columns),
+        n_permutations=10,
+        permutation_test=True,
+        seed=0,
+    )
+    assert res["p"].notna().values.sum() > 0
+    assert res["z"].notna().values.sum() > 0


### PR DESCRIPTION
## Summary
- fix mutual information permutation computation by correctly parallelizing `mutual_info_regression` calls and deriving net MI, z-scores, and p-values
- collapse `--mi-permutation` and `--mi-permutations` into a single `--mi-permutations` flag; update README usage
- test mutual information analysis with permutation to ensure p/z matrices are populated

## Testing
- `PYTHONPATH=. pytest tests/test_mutual_info.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'ancpbids')*


------
https://chatgpt.com/codex/tasks/task_e_68907f13b9dc8326909b4643c0642103