### PR TITLE
Add summary QC report generation

### DIFF
--- a/tests/test_summary_qc_report.py
+++ b/tests/test_summary_qc_report.py
@@ -1,0 +1,28 @@
+import json
+
+from meg_qc.plotting.universal_html_report import make_summary_qc_report
+
+
+def test_make_summary_qc_report(tmp_path):
+    report_path = tmp_path / "desc-ReportStrings_meg.json"
+    simple_path = tmp_path / "desc-SimpleMetrics_meg.json"
+
+    report_content = {"INITIAL_INFO": "Data resampled to 1000 Hz."}
+    simple_content = {
+        "STD": {
+            "measurement_unit_mag": "Tesla",
+            "STD_all_time_series": {
+                "MAGNETOMETERS": {"number_of_noisy_ch": 1},
+            },
+        }
+    }
+
+    report_path.write_text(json.dumps(report_content))
+    simple_path.write_text(json.dumps(simple_content))
+
+    html = make_summary_qc_report(str(report_path), str(simple_path))
+
+    assert "Data resampled to 1000 Hz." in html
+    assert "number_of_noisy_ch" in html
+    assert "<table" in html
+


### PR DESCRIPTION
## Summary
- Generate table-only Summary QC report from simple metrics and report strings
- Produce summary report per subject/task during plotting
- Test HTML summary generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933c8625f88326a698d28bc88a9f85