### PR TITLE
Handle list inputs in HTML summary

### DIFF
--- a/meg_qc/plotting/universal_html_report.py
+++ b/meg_qc/plotting/universal_html_report.py
@@ -404,18 +404,30 @@ def simple_metric_basic(metric_global_name: str, metric_global_description: str,
     return simple_metric
 
 
-def _dict_to_html_tables(data: dict, level: int = 0) -> str:
-    """Convert a nested dictionary into HTML tables."""
+def _dict_to_html_tables(data, level: int = 0) -> str:
+    """Convert a nested dictionary or list into HTML tables."""
 
     rows = []
     nested = []
-    for key, value in data.items():
-        if isinstance(value, dict):
-            nested.append((key, value))
-        else:
-            if isinstance(value, list):
-                value = ", ".join(str(v) for v in value)
-            rows.append({"Field": key, "Value": value})
+
+    if isinstance(data, list):
+        for idx, item in enumerate(data):
+            if isinstance(item, (dict, list)):
+                nested.append((f"Item {idx + 1}", item))
+            else:
+                rows.append({"Field": idx, "Value": item})
+    else:
+        for key, value in data.items():
+            if isinstance(value, dict):
+                nested.append((key, value))
+            elif isinstance(value, list):
+                if value and all(isinstance(v, dict) for v in value):
+                    nested.append((key, value))
+                else:
+                    value = ", ".join(str(v) for v in value)
+                    rows.append({"Field": key, "Value": value})
+            else:
+                rows.append({"Field": key, "Value": value})
 
     html = ""
     if rows:

--- a/tests/test_summary_qc_report.py
+++ b/tests/test_summary_qc_report.py
@@ -26,3 +26,19 @@ def test_make_summary_qc_report(tmp_path):
     assert "number_of_noisy_ch" in html
     assert "<table" in html
 
+
+def test_make_summary_qc_report_handles_list(tmp_path):
+    report_path = tmp_path / "desc-ReportStrings_meg.json"
+    simple_path = tmp_path / "desc-SimpleMetrics_meg.json"
+
+    report_content = {"INITIAL_INFO": "Data resampled to 1000 Hz."}
+    simple_content = {"STD": [], "PSD": [{"measurement_unit_mag": "Tesla"}]}
+
+    report_path.write_text(json.dumps(report_content))
+    simple_path.write_text(json.dumps(simple_content))
+
+    html = make_summary_qc_report(str(report_path), str(simple_path))
+
+    assert "<h2>STD</h2>" in html
+    assert "measurement_unit_mag" in html
+


### PR DESCRIPTION
## Summary
- ensure `_dict_to_html_tables` supports lists, avoiding AttributeError when metrics are missing or list-based
- add regression test covering list inputs in summary metrics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68934989565c8326b92cdba356304516